### PR TITLE
Remove Appdir author

### DIFF
--- a/fediplug/dirs.py
+++ b/fediplug/dirs.py
@@ -3,4 +3,4 @@
 from appdirs import AppDirs
 
 
-DIRS = AppDirs('fediplug', 'zigg')
+DIRS = AppDirs('fediplug', appauthor=False)


### PR DESCRIPTION
The Appdir author name is a windows only feature and still contained the upstream author.