### PR TITLE
Parse device instructions from toots

### DIFF
--- a/fediplug/buttplugio.py
+++ b/fediplug/buttplugio.py
@@ -36,20 +36,22 @@ async def scan_devices(plug_client):
     return plug_client
 
 
-async def trigger_actuators(plug_client, play_command):
+async def trigger_actuators(plug_client, actuator_command):
+    MAX_DURATION = 60  # maximum duration in seconds
+    MAX_POWER = 1  # has to be 0 <= n <= 1 or it will not work
+    duration = clamp(actuator_command[0], 0, MAX_DURATION)
+    power = clamp(actuator_command[1], 0, MAX_POWER)
     # If we have any device we can access it by its ID:
     device = plug_client.devices[0]
-    # The most common case among devices is that they have some actuators
-    # which accept a scalar value (0.0-1.0) as their command.
-    play_command = (1, 1)
     if len(device.actuators) != 0:
         print(len(device.actuators), "actuators found")
         # cycle through all actuators in device
         print(device.actuators)
+        print(f"{duration=} {power=}")
         for actuator in device.actuators:
-            await actuator.command(play_command[0])
+            await actuator.command(power)
             print("generic actuator")
-        await asyncio.sleep(play_command[1])
+        await asyncio.sleep(duration)
         #stops all actuators
         for actuator in device.actuators:
             await actuator.command(0)
@@ -73,6 +75,9 @@ async def disconnect_plug_client(plug_client):
     # Disconnect the plug_client.
     await plug_client.disconnect()
 
+def clamp(n, smallest, largest):
+    '''returns the closest value to n still in range (clamp)'''
+    return max(smallest, min(n, largest))
 
 # First things first. We set logging to the console and at INFO level.
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/fediplug/mastodon.py
+++ b/fediplug/mastodon.py
@@ -102,15 +102,6 @@ def stream(instance, users, client_id, client_secret, access_token, plug_client,
     users = [normalize_username(user, instance) for user in users]
     listener = StreamListener(plug_client, instance, users, event_loop)
     
-
-    existing_statuses = client.timeline_hashtag(LISTEN_TO_HASHTAG, limit=1)
-
-    if options['debug']:
-        print(rf'existing_statuses: {existing_statuses}')
-
-    for status in existing_statuses:
-        listener.on_update(status)
-
     click.echo(f'==> Streaming from {instance}')
     client.stream_user(listener)
 


### PR DESCRIPTION
Fixes #4 
Adds a way to pass instructions to buttplug.io device via toot in the format 1s 10s 50% 3s 5s ..., where the percentage refers to power and refers to all previous values since last percentage or beginning. If no percentage is given, a default is used (currently 100%). Here 1s and 10s would execute at 50% an 3s 5s would execute at default = 100%